### PR TITLE
Fix "ScrollController not attached to any scroll views."

### DIFF
--- a/lib/scroll_loop_auto_scroll.dart
+++ b/lib/scroll_loop_auto_scroll.dart
@@ -121,7 +121,8 @@ class _ScrollLoopAutoScrollState extends State<ScrollLoopAutoScroll>
   }
 
   animationHandler() async {
-    if (scrollController.position.maxScrollExtent > 0) {
+    if (scrollController.hasClients &&
+        scrollController.position.maxScrollExtent > 0) {
       shouldScroll.value = true;
 
       if (shouldScroll.value && mounted) {


### PR DESCRIPTION
This should fix this error I was getting:

```
[ERROR:flutter/runtime/dart_vm_initializer.cc(41)] Unhandled Exception: 'package:flutter/src/widgets/scroll_controller.dart': Failed assertion: line 105 pos 12: '_positions.isNotEmpty': ScrollController not attached to any scroll views.
scroll_controller.dart:105
#0      _AssertionError._doThrowNew (dart:core-patch/errors_patch.dart:51:61)
#1      _AssertionError._throwNew (dart:core-patch/errors_patch.dart:40:5)
#2      ScrollController.position
scroll_controller.dart:105
#3      _ScrollLoopAutoScrollState.animationHandler
scroll_loop_auto_scroll.dart:124
#4      _ScrollLoopAutoScrollState.initState.<anonymous closure>
scroll_loop_auto_scroll.dart:117
<asynchronous suspension>
```

This is because in this part of the code it is calling `animationHandler()` after an asynchronous gap and not checking if there are clients positions before accessing `scrollController.position`

```
WidgetsBinding
.instance.addPostFrameCallback((timeStamp) async {
      await Future.delayed(widget.delay);
      animationHandler();
    });
```
